### PR TITLE
feat: Add subhighlight creation and deletion endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.ignoreWords": ["Subhighlight"]
+}

--- a/src/highlight/highlight.controller.ts
+++ b/src/highlight/highlight.controller.ts
@@ -116,4 +116,37 @@ export class HighlightController {
       return { status: HttpStatus.INTERNAL_SERVER_ERROR };
     }
   }
+
+  @Post(':id/sub')
+  @HttpCode(HttpStatus.OK)
+  async createSubhighlight(
+    @Param('id') id: string,
+    @Body() body: { startIndex: number; endIndex: number },
+  ): Promise<{ status: number }> {
+    console.log('createSubhighlight', id, body);
+    const { startIndex, endIndex } = body;
+    try {
+      await this.highlightService.createSubhighlight(id, startIndex, endIndex);
+      return { status: HttpStatus.OK };
+    } catch (error) {
+      console.error('Error creating subhighlight:', error);
+      return { status: HttpStatus.INTERNAL_SERVER_ERROR };
+    }
+  }
+
+  @Delete('sub/:subId')
+  @HttpCode(HttpStatus.OK)
+  async deleteSubhighlight(
+    @Param('subId') subId: string,
+  ): Promise<{ status: number }> {
+    try {
+      await this.highlightService.deleteSubhighlight(subId);
+      return { status: HttpStatus.OK };
+    } catch (error) {
+      console.error('Error deleting subhighlight:', error);
+      return {
+        status: HttpStatus.INTERNAL_SERVER_ERROR,
+      };
+    }
+  }
 }

--- a/src/highlight/highlight.service.ts
+++ b/src/highlight/highlight.service.ts
@@ -61,6 +61,7 @@ export class HighlightService {
       orderBy,
       include: {
         notes: true,
+        subHighlights: true,
       },
     });
   }
@@ -132,6 +133,28 @@ export class HighlightService {
     await this.prisma.highlight.update({
       where: { id: highlightId },
       data: { content },
+    });
+  }
+
+  async createSubhighlight(
+    highlightId: string,
+    startIndex: number,
+    endIndex: number,
+  ) {
+    await this.prisma.subHighlight.create({
+      data: {
+        highlightId,
+        startIndex,
+        endIndex,
+      },
+    });
+  }
+
+  async deleteSubhighlight(subHighlightId: string) {
+    await this.prisma.subHighlight.delete({
+      where: {
+        id: subHighlightId,
+      },
     });
   }
 }


### PR DESCRIPTION
- Implemented POST endpoint to create subhighlight for a specific highlight
- Added DELETE endpoint to remove individual subhighlight
- Updated HighlightService with methods to create and delete subhighlight via Prisma
- Included error handling and appropriate HTTP status codes
- Added subhighlight inclusion in highlight retrieval query
- Updated VSCode settings to ignore 'Subhighlight' spelling